### PR TITLE
Fix Distributed Rosbag Sync

### DIFF
--- a/output.proto
+++ b/output.proto
@@ -55,6 +55,7 @@ message SystemHealth {
       INPUT_NOT_AVAILABLE = 7;
       INITIALIZATION_ERROR = 8;
       VERSION_MISMATCH = 9;
+      EMPTY_ROSBAG_PLAY = 10;
     }
     enum SensorStatus {
       SENSOR_DEAD = 0;

--- a/output.proto
+++ b/output.proto
@@ -45,6 +45,7 @@ message SystemHealth {
   }
   message Node {
     enum Status {
+      reserved 7;
       NONE = 0;
       OK = 1;
       ROS_ERROR = 2;
@@ -52,7 +53,6 @@ message SystemHealth {
       INVALID_GPU_CONFIGURATION = 4;
       NETWORK_LATENCY = 5;
       INVALID_CONFIG = 6;
-      INPUT_NOT_AVAILABLE = 7;
       INITIALIZATION_ERROR = 8;
       VERSION_MISMATCH = 9;
       EMPTY_ROSBAG_PLAY = 10;


### PR DESCRIPTION
Remove unused node status: `INPUT_NOT_AVAILABLE`